### PR TITLE
Radius => RADIUS のルールを削除

### DIFF
--- a/lib/term_rule.yaml
+++ b/lib/term_rule.yaml
@@ -1054,9 +1054,6 @@ rules:
 #  - expected: Python
 #    pattern: /\bPython\b/i
 
-  - expected: RADIUS
-    pattern: /\bRADIUS\b/i
-
   # ★Rails3★
   - expected: Rails $1
     pattern: /Rails([0-9])/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "textlint-rule-preset-dwango-progedu",
-  "version": "1.1.10",
+  "version": "1.1.11",
   "description": "ドワンゴN予備校向けプログラミング教育テキスト群において用いているtextlintの標準設定",
   "main": "lib/textlint-rule-preset-dwango-progedu.js",
   "scripts": {


### PR DESCRIPTION
Radius => RADIUS のルールを削除しました。
マージ後に `npm publish` します。
fix #15