### PR TITLE
Apple 、 iPadOS 、 Word についてのルールを追加変更

### DIFF
--- a/lib/term_rule.yaml
+++ b/lib/term_rule.yaml
@@ -657,6 +657,12 @@ rules:
   - expected: ASP.NET
     pattern: /ASP \.NET/
 
+  - expected: Apple
+    pattern: /\bApple\b/i
+
+  - expected: Apple
+    pattern: アップル
+
   - expected: Bean
     pattern: ビーン
 
@@ -839,6 +845,9 @@ rules:
 
   - expected: iPad
     pattern: /\biPad\b/i
+
+  - expected: iPadOS
+    pattern: /\biPad OS\b/i
 
   - expected: iPhone
     pattern: /\biPhone\b/i
@@ -1285,7 +1294,7 @@ rules:
     pattern: /\bWindowsXP\b/
 
   - expected: $1Word
-    pattern: /([^ースォ])ワード/
+    pattern: /([^ースォ索外う])ワード/
 
   - expected: xAuth
     pattern: /\bxAuth\b/i


### PR DESCRIPTION
PC 基礎コースの textlint 導入に伴ってルール変更した部分の PR です。
ご確認のほどよろしくお願いいたします 🙇 

https://github.com/progedu/computer-basics/pull/1028

- Apple 社 について言及する際は "アップル" ではなく "Apple" に統一させた
- "iPadOS" に統一するルールを追加
- "Word” に誤ってマッチするパターンを消すようにルールを修正

