### PR TITLE
fix/19 i フラグを VSCode の表記揺れに追加

### DIFF
--- a/lib/term_rule.yaml
+++ b/lib/term_rule.yaml
@@ -1736,7 +1736,7 @@ rules:
     pattern: /ネスティング|ネスト/
 
   - expected: VS Code
-    pattern: VSCode
+    pattern: /VSCode/i
 
   - expected: 1 つ
     pattern: /1つ|１つ/


### PR DESCRIPTION
fix #19 

i フラグを追加しました。