### PR TITLE
macOS のルールを修正

### DIFF
--- a/lib/term_rule.yaml
+++ b/lib/term_rule.yaml
@@ -945,8 +945,8 @@ rules:
   - expected: LL
     pattern: LL言語
 
-  - expected: Mac OS
-    pattern: /\bMacOS\b/
+  - expected: macOS
+    pattern: /Mac OS(?! X)/i
 
   - expected: Mac OS X
     pattern: /\bMacOSX\b/


### PR DESCRIPTION
<q>macOS</q> になるように修正しました。
fix #23 