### PR TITLE
「1 つ」「2 つ」のルールを削除

### DIFF
--- a/lib/term_rule.yaml
+++ b/lib/term_rule.yaml
@@ -1747,12 +1747,6 @@ rules:
   - expected: VS Code
     pattern: /VSCode/i
 
-  - expected: 1 つ
-    pattern: /1つ|１つ/
-
-  - expected: 2 つ
-    pattern: /2つ|２つ/
-
   - expected: Slack
     pattern: slack
 


### PR DESCRIPTION
「1 つ」「2 つ」のルールを削除しました。
半角文字と全角文字の間のスペースの有無は [ja-space-between-half-and-full-width](https://www.npmjs.com/package/textlint-rule-ja-space-between-half-and-full-width) で指定できます。
fix #26 